### PR TITLE
fix(deps): remove duplicate devDependencies and bump versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2025-12-10
+
+### Fixed
+
+- Remove duplicate devDependencies entries in package.json that caused CI failures
+
+### Changed
+
+- Bump @types/node from 24.5.2 to 24.10.2
+- Bump packageManager from npm@11.6.0 to npm@11.7.0
+
 ## [0.1.0] - 2025-09-07
 
 ### Added
@@ -19,4 +30,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for custom prompts in .codex/prompts/
 - Production-ready TypeScript implementation
 
+[0.1.1]: https://github.com/RMNCLDYO/create-codex/releases/tag/v0.1.1
 [0.1.0]: https://github.com/RMNCLDYO/create-codex/releases/tag/v0.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,10 +22,8 @@
         "create-codex": "dist/cli.js"
       },
       "devDependencies": {
-        "@types/node": "^24.5.2",
+        "@types/node": "^24.10.2",
         "typescript": "^5.9.3"
-        "@types/node": "^24.10.0",
-        "typescript": "^5.9.2"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -37,9 +35,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.10.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
-      "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
+      "version": "24.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.2.tgz",
+      "integrity": "sha512-WOhQTZ4G8xZ1tjJTvKOpyEVSGgOTvJAfDK3FNFgELyaTpzhdgHVHeqW8V+UJvzF5BT+/B54T/1S2K6gd9c7bbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "create-codex",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "AGENTS.md setup that just works. Bootstrap every project with a config file that works with most of your favorite code editors. One command, zero headaches.",
   "type": "module",
   "sideEffects": false,
   "private": false,
-  "packageManager": "npm@11.6.0",
+  "packageManager": "npm@11.7.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -106,9 +106,7 @@
   "preferGlobal": false,
   "stability": "stable",
   "devDependencies": {
-    "@types/node": "^24.5.2",
+    "@types/node": "^24.10.2",
     "typescript": "^5.9.3"
-    "@types/node": "^24.10.0",
-    "typescript": "^5.9.2"
   }
 }


### PR DESCRIPTION
## Summary

- Fix duplicate `@types/node` and `typescript` entries in devDependencies that caused CI failures
- Bump `@types/node` from 24.5.2 to 24.10.2
- Bump `packageManager` from npm@11.6.0 to npm@11.7.0
- Version bump to 0.1.1

## Changes by Layer

**Config:** package.json, package-lock.json
**Docs:** CHANGELOG.md

## Impact

- **Performance:** None
- **Bundle size:** None
- **Breaking changes:** None
- **Migrations:** None